### PR TITLE
:sparkles: S3 설정 및 이미지 업로드 기능 구현

### DIFF
--- a/src/main/java/org/codeit/roomunion/RoomunionApplication.java
+++ b/src/main/java/org/codeit/roomunion/RoomunionApplication.java
@@ -1,9 +1,13 @@
 package org.codeit.roomunion;
 
+import org.codeit.roomunion.common.config.S3.AmazonProperties;
+import org.codeit.roomunion.common.config.S3.S3Properties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties({AmazonProperties.class, S3Properties.class})
 public class RoomunionApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/codeit/roomunion/auth/adapter/in/filter/LoginFilter.java
+++ b/src/main/java/org/codeit/roomunion/auth/adapter/in/filter/LoginFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.codeit.roomunion.auth.domain.model.CustomUserDetails;
 import org.codeit.roomunion.common.exception.ErrorCode;
 import org.codeit.roomunion.common.jwt.JwtUtil;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
@@ -22,16 +23,22 @@ import java.util.Map;
 
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
-    private final long EXPIRATION = Duration.ofHours(24).toMillis() * 7; // 7 days
+    private final long EXPIRATION;
 
     private final JwtUtil jwtUtil;
     private final AuthenticationManager authenticationManager;
     private final ObjectMapper objectMapper;
 
-    public LoginFilter(JwtUtil jwtUtil, AuthenticationManager authenticationManager) {
+    public LoginFilter(
+        JwtUtil jwtUtil,
+        AuthenticationManager authenticationManager,
+        @Value("${spring.jwt.access-token-expire-time}") long expiration
+    ) {
         this.jwtUtil = jwtUtil;
         this.authenticationManager = authenticationManager;
         this.objectMapper = new ObjectMapper();
+        this.EXPIRATION = expiration;
+
         setFilterProcessesUrl("/auth/login");
     }
 

--- a/src/main/java/org/codeit/roomunion/auth/config/SecurityConfig.java
+++ b/src/main/java/org/codeit/roomunion/auth/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.codeit.roomunion.auth.adapter.in.filter.JwtAuthenticationFilter;
 import org.codeit.roomunion.auth.adapter.in.filter.LoginFilter;
 import org.codeit.roomunion.common.jwt.JwtUtil;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -33,9 +34,12 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtUtil jwtUtil;
 
+    @Value("${spring.jwt.access-token-expire-time}")
+    private long accessTokenExpireTime;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        LoginFilter loginFilter = new LoginFilter(jwtUtil, authenticationManager(authenticationConfiguration));
+        LoginFilter loginFilter = new LoginFilter(jwtUtil, authenticationManager(authenticationConfiguration), accessTokenExpireTime);
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfig.corsConfigurationSource()))

--- a/src/main/java/org/codeit/roomunion/common/adapter/out/AmazonS3Manager.java
+++ b/src/main/java/org/codeit/roomunion/common/adapter/out/AmazonS3Manager.java
@@ -1,4 +1,4 @@
-package org.codeit.roomunion.common.config.S3;
+package org.codeit.roomunion.common.adapter.out;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -6,7 +6,8 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.codeit.roomunion.common.adapter.out.persistence.entity.UuidEntity;
-import org.codeit.roomunion.common.adapter.out.persistence.jpa.UuidRepository;
+import org.codeit.roomunion.common.adapter.out.persistence.jpa.UuidJpaRepository;
+import org.codeit.roomunion.common.config.S3.S3Properties;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -21,7 +22,7 @@ public class AmazonS3Manager {
 
     private final S3Properties s3Properties;
 
-    private final UuidRepository uuidRepository;
+    private final UuidJpaRepository uuidJpaRepository;
 
     public String uploadFile(String keyName, MultipartFile file){
         ObjectMetadata metadata = new ObjectMetadata();

--- a/src/main/java/org/codeit/roomunion/common/adapter/out/persistence/entity/UuidEntity.java
+++ b/src/main/java/org/codeit/roomunion/common/adapter/out/persistence/entity/UuidEntity.java
@@ -1,4 +1,4 @@
-package org.codeit.roomunion.common.config.S3;
+package org.codeit.roomunion.common.adapter.out.persistence.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class Uuid {
+public class UuidEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/codeit/roomunion/common/adapter/out/persistence/jpa/UuidJpaRepository.java
+++ b/src/main/java/org/codeit/roomunion/common/adapter/out/persistence/jpa/UuidJpaRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UuidRepository extends JpaRepository<UuidEntity, Long> {
+public interface UuidJpaRepository extends JpaRepository<UuidEntity, Long> {
 }

--- a/src/main/java/org/codeit/roomunion/common/adapter/out/persistence/jpa/UuidRepository.java
+++ b/src/main/java/org/codeit/roomunion/common/adapter/out/persistence/jpa/UuidRepository.java
@@ -1,0 +1,9 @@
+package org.codeit.roomunion.common.adapter.out.persistence.jpa;
+
+import org.codeit.roomunion.common.adapter.out.persistence.entity.UuidEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UuidRepository extends JpaRepository<UuidEntity, Long> {
+}

--- a/src/main/java/org/codeit/roomunion/common/adapter/out/s3/AmazonS3Manager.java
+++ b/src/main/java/org/codeit/roomunion/common/adapter/out/s3/AmazonS3Manager.java
@@ -36,13 +36,6 @@ public class AmazonS3Manager {
 
         return amazonS3.getUrl(s3Properties.getBucket(), keyName).toString();
     }
-
-    public String generateProfile(UuidEntity uuidEntity) {
-        return s3Properties.getPath().getProfile() + '/' + uuidEntity.getUuid();
-    }
-
-    public String generateCrew(UuidEntity uuidEntity) {
-        return s3Properties.getPath().getCrew() + '/' + uuidEntity.getUuid();
-    }
+    
 
 }

--- a/src/main/java/org/codeit/roomunion/common/adapter/out/s3/AmazonS3Manager.java
+++ b/src/main/java/org/codeit/roomunion/common/adapter/out/s3/AmazonS3Manager.java
@@ -1,4 +1,4 @@
-package org.codeit.roomunion.common.adapter.out;
+package org.codeit.roomunion.common.adapter.out.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;

--- a/src/main/java/org/codeit/roomunion/common/config/S3/AmazonConfig.java
+++ b/src/main/java/org/codeit/roomunion/common/config/S3/AmazonConfig.java
@@ -1,0 +1,58 @@
+package org.codeit.roomunion.common.config.S3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class AmazonConfig {
+
+    private AWSCredentials awsCredentials;
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.path.profile}")
+    private String profilePath;
+
+    @Value("${cloud.aws.s3.path.crew}")
+    private String crewPath;
+
+    @PostConstruct
+    public void init() {
+        this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+            .withRegion(region)
+            .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+            .build();
+    }
+
+    @Bean
+    public AWSCredentialsProvider awsCredentialsProvider() {
+        return new AWSStaticCredentialsProvider(awsCredentials);
+    }
+}

--- a/src/main/java/org/codeit/roomunion/common/config/S3/AmazonProperties.java
+++ b/src/main/java/org/codeit/roomunion/common/config/S3/AmazonProperties.java
@@ -1,0 +1,37 @@
+package org.codeit.roomunion.common.config.S3;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "cloud.aws")
+public class AmazonProperties {
+
+    private final Credentials credentials;
+    private final Region region;
+
+    public AmazonProperties(Credentials credentials, Region region) {
+        this.credentials = credentials;
+        this.region = region;
+    }
+
+    @Getter
+    public static class Credentials{
+        private final String accessKey;
+        private final String secretKey;
+
+        public Credentials(String accessKey, String secretKey) {
+            this.accessKey = accessKey;
+            this.secretKey = secretKey;
+        }
+    }
+
+    @Getter
+    public static class Region {
+        private final String staticRegion;
+
+        public Region(String staticRegion) {
+            this.staticRegion = staticRegion;
+        }
+    }
+}

--- a/src/main/java/org/codeit/roomunion/common/config/S3/AmazonS3Manager.java
+++ b/src/main/java/org/codeit/roomunion/common/config/S3/AmazonS3Manager.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.codeit.roomunion.common.adapter.out.persistence.entity.UuidEntity;
+import org.codeit.roomunion.common.adapter.out.persistence.jpa.UuidRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,7 +19,7 @@ public class AmazonS3Manager {
 
     private final AmazonS3 amazonS3;
 
-    private final AmazonConfig amazonConfig;
+    private final S3Properties s3Properties;
 
     private final UuidRepository uuidRepository;
 
@@ -26,24 +28,20 @@ public class AmazonS3Manager {
         metadata.setContentType(file.getContentType());
         metadata.setContentLength(file.getSize());
         try {
-            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
+            amazonS3.putObject(new PutObjectRequest(s3Properties.getBucket(), keyName, file.getInputStream(), metadata));
         }catch (IOException e){
             log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
         }
 
-        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+        return amazonS3.getUrl(s3Properties.getBucket(), keyName).toString();
     }
 
-    // keyName 생성
-
-    // 프로필 이미지 keyName
-    public String generateProfile(Uuid uuid) {
-        return amazonConfig.getProfilePath() + '/' + uuid.getUuid();
+    public String generateProfile(UuidEntity uuidEntity) {
+        return s3Properties.getPath().getProfile() + '/' + uuidEntity.getUuid();
     }
 
-    // 크루(모임) 이미지 keyName
-    public String generateCrew(Uuid uuid) {
-        return amazonConfig.getCrewPath() + '/' + uuid.getUuid();
+    public String generateCrew(UuidEntity uuidEntity) {
+        return s3Properties.getPath().getCrew() + '/' + uuidEntity.getUuid();
     }
 
 }

--- a/src/main/java/org/codeit/roomunion/common/config/S3/AmazonS3Manager.java
+++ b/src/main/java/org/codeit/roomunion/common/config/S3/AmazonS3Manager.java
@@ -1,0 +1,49 @@
+package org.codeit.roomunion.common.config.S3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AmazonS3Manager {
+
+    private final AmazonS3 amazonS3;
+
+    private final AmazonConfig amazonConfig;
+
+    private final UuidRepository uuidRepository;
+
+    public String uploadFile(String keyName, MultipartFile file){
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+        try {
+            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
+        }catch (IOException e){
+            log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
+        }
+
+        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+    // keyName 생성
+
+    // 프로필 이미지 keyName
+    public String generateProfile(Uuid uuid) {
+        return amazonConfig.getProfilePath() + '/' + uuid.getUuid();
+    }
+
+    // 크루(모임) 이미지 keyName
+    public String generateCrew(Uuid uuid) {
+        return amazonConfig.getCrewPath() + '/' + uuid.getUuid();
+    }
+
+}

--- a/src/main/java/org/codeit/roomunion/common/config/S3/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/org/codeit/roomunion/common/config/S3/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,31 @@
+package org.codeit.roomunion.common.config.S3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/org/codeit/roomunion/common/config/S3/S3Properties.java
+++ b/src/main/java/org/codeit/roomunion/common/config/S3/S3Properties.java
@@ -1,0 +1,29 @@
+package org.codeit.roomunion.common.config.S3;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "cloud.aws.s3")
+public class S3Properties {
+
+    private final String bucket;
+    private final Path path;
+
+    public S3Properties(String bucket, Path path) {
+        this.bucket = bucket;
+        this.path = path;
+    }
+
+    @Getter
+    public static class Path {
+        private final String profile;
+        private final String crew;
+
+        public Path(String profile, String crew) {
+            this.profile = profile;
+            this.crew = crew;
+        }
+
+    }
+}

--- a/src/main/java/org/codeit/roomunion/common/config/S3/Uuid.java
+++ b/src/main/java/org/codeit/roomunion/common/config/S3/Uuid.java
@@ -1,0 +1,22 @@
+package org.codeit.roomunion.common.config.S3;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Uuid {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String uuid;
+}

--- a/src/main/java/org/codeit/roomunion/common/config/S3/UuidRepository.java
+++ b/src/main/java/org/codeit/roomunion/common/config/S3/UuidRepository.java
@@ -1,0 +1,8 @@
+package org.codeit.roomunion.common.config.S3;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UuidRepository extends JpaRepository<Uuid, Long> {
+}

--- a/src/main/java/org/codeit/roomunion/common/config/S3/UuidRepository.java
+++ b/src/main/java/org/codeit/roomunion/common/config/S3/UuidRepository.java
@@ -1,8 +1,0 @@
-package org.codeit.roomunion.common.config.S3;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface UuidRepository extends JpaRepository<Uuid, Long> {
-}

--- a/src/main/java/org/codeit/roomunion/common/config/converter/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/org/codeit/roomunion/common/config/converter/MultipartJackson2HttpMessageConverter.java
@@ -1,4 +1,4 @@
-package org.codeit.roomunion.common.config.S3;
+package org.codeit.roomunion.common.config.converter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.MediaType;

--- a/src/main/java/org/codeit/roomunion/crew/domain/model/Crew.java
+++ b/src/main/java/org/codeit/roomunion/crew/domain/model/Crew.java
@@ -1,0 +1,16 @@
+package org.codeit.roomunion.crew.domain.model;
+
+import lombok.Getter;
+import org.codeit.roomunion.common.adapter.out.persistence.entity.UuidEntity;
+import org.codeit.roomunion.common.config.S3.S3Properties;
+
+@Getter
+public class Crew {
+    private Long id;
+
+
+    public String crewImageKey(S3Properties s3Properties, UuidEntity uuidEntity) {
+        return s3Properties.getPath().getCrew() + '/' + uuidEntity.getUuid();
+    }
+
+}

--- a/src/main/java/org/codeit/roomunion/user/adapter/out/persistence/UserRepositoryImpl.java
+++ b/src/main/java/org/codeit/roomunion/user/adapter/out/persistence/UserRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.codeit.roomunion.user.adapter.out.persistence;
 
 import org.codeit.roomunion.common.exception.UserNotFoundException;
 import org.codeit.roomunion.user.adapter.out.persistence.entity.UserEntity;
+import org.codeit.roomunion.user.adapter.out.persistence.jpa.UserJpaRepository;
 import org.codeit.roomunion.user.application.port.out.UserRepository;
 import org.codeit.roomunion.user.domain.model.User;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/org/codeit/roomunion/user/adapter/out/persistence/jpa/UserJpaRepository.java
+++ b/src/main/java/org/codeit/roomunion/user/adapter/out/persistence/jpa/UserJpaRepository.java
@@ -1,4 +1,4 @@
-package org.codeit.roomunion.user.adapter.out.persistence;
+package org.codeit.roomunion.user.adapter.out.persistence.jpa;
 
 import org.codeit.roomunion.user.adapter.out.persistence.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/org/codeit/roomunion/user/domain/model/User.java
+++ b/src/main/java/org/codeit/roomunion/user/domain/model/User.java
@@ -1,6 +1,8 @@
 package org.codeit.roomunion.user.domain.model;
 
 import lombok.Getter;
+import org.codeit.roomunion.common.adapter.out.persistence.entity.UuidEntity;
+import org.codeit.roomunion.common.config.S3.S3Properties;
 
 @Getter
 public class User {
@@ -22,5 +24,9 @@ public class User {
 
     public static User of(Long id, String email, String password, String name, String nickname, String description) {
         return new User(id, email, password, name, nickname, description);
+    }
+
+    public String profileImageKey(S3Properties s3Properties, UuidEntity uuidEntity) {
+        return s3Properties.getPath().getProfile() + "/" + uuidEntity.getUuid();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,19 @@ spring:
     secret: e253645a97f98c5ac9d94c7cb6fe47adef76834f1ebf312d9617564096f443ad
     access-token-expire-time: 7200000
     refresh-token-expire-time: 172800000
+
+# S3
+cloud:
+  aws:
+    s3:
+      bucket: ${CLOUD_AWS_S3_BUCKET}
+      path:
+        profile: profile
+        crew: crew
+    region:
+      static: ${CLOUD_AWS_REGION_STATIC}
+    stack:
+      auto: false
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY_ID}
+      secretKey: ${AWS_SECRET_ACCESS_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,9 +46,9 @@ cloud:
         profile: profile
         crew: crew
     region:
-      static: ${CLOUD_AWS_REGION_STATIC}
+      static-region: ${CLOUD_AWS_REGION_STATIC}
     stack:
       auto: false
     credentials:
-      accessKey: ${AWS_ACCESS_KEY_ID}
-      secretKey: ${AWS_SECRET_ACCESS_KEY}
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
## 📌 PR 요약 (하나 이상 선택해주세요)

- [x] S3 설정 및 이미지 업로드 기능 구현
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

---

## 💡 주요 변경사항

-  AmazonS3 설정을 위한 설정 파일들은 Config에 다 넣어놨습니다. MultipartJackson2HttpMessageConverter는 멀티파트 요청에서 JSON이 application/json이 아닌 application/octet-stream 같은 예외로 들어올 때도 Jackson으로 파싱하기 위해 만든 보조 컨버터입니다.이미지는 이미지 이름만으로 구분하기 힘들기에 uuid를 통해서 이미지를 구분해주었습니다. **application.yml에 추가적으로 s3 설정 환경변수를 넣었기에 SpringBoot 환경 변수에 값 대입해서 넣으시면 됩니다. S3 사용해서 이미지 업로드 기능 구현 하는법도 노션에 정리했습니다.**
application.yml 값 :  https://www.notion.so/room-union/application-yml-272a6f55bb7280b5b9ccf280e09c4fd2
S3 사용해서 이미지 업로드 : https://www.notion.so/room-union/S3-279a6f55bb7280629925e69bc41d575d
## 🔍 관련 이슈

- #

---

## 🌿 브랜치 정보

- 병합 대상 브랜치: feat/s3
- 현재 작업 브랜치: dev

---

## 🧪 테스트 방법

- ***

## ⚠️ 주의사항

-
